### PR TITLE
Add print command

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/bmatcuk/doublestar"
+	"github.com/charypar/monobuild/manifests"
+	"github.com/spf13/cobra"
+)
+
+var printCmd = &cobra.Command{
+	Use:   "print",
+	Short: "print the dependency graph",
+	Long:  `Read the dependency graph from dependency manifests, check all dependencies exist and pretty print it`,
+	Run:   printFn,
+}
+
+var dotFormat bool
+
+func init() {
+	rootCmd.AddCommand(printCmd)
+
+	printCmd.Flags().BoolVar(&dotFormat, "dot", false, "Output the dependencies in DOT format for GraphViz")
+}
+
+func printFn(cmd *cobra.Command, args []string) {
+	paths, err := doublestar.Glob(dependencyFilesGlob)
+	if err != nil {
+		panic(fmt.Errorf("Error finding dependency manifests: %s", err))
+	}
+
+	components, dependencies, errs := manifests.Read(paths, false)
+	if errs != nil {
+		for _, e := range errs {
+			fmt.Printf("Error: %s\n", e)
+		}
+		fmt.Println("")
+	}
+
+	if errs != nil && dotFormat {
+		return
+	}
+
+	if !dotFormat {
+		fmt.Printf("Found %d component(s). Dependency structure:\n\n", len(components))
+		for c, d := range dependencies {
+			fmt.Printf("%s -> %s\n", c, strings.Join(d, ", "))
+		}
+	} else {
+		fmt.Println("digraph graphname {")
+
+		for c, deps := range dependencies {
+			for _, d := range deps {
+				fmt.Printf("  %s -> %s\n", c, d)
+			}
+		}
+
+		fmt.Println("}")
+	}
+}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -52,7 +52,7 @@ func printFn(cmd *cobra.Command, args []string) {
 
 		for c, deps := range dependencies {
 			for _, d := range deps {
-				fmt.Printf("  %s -> %s\n", c, d)
+				fmt.Printf("  \"%s\" -> \"%s\"\n", c, d)
 			}
 		}
 

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/charypar/monobuild/graph"
+	"github.com/charypar/monobuild/manifests"
 	"github.com/charypar/monobuild/set"
 )
 
@@ -58,9 +59,14 @@ func changedComponents(components []string, changedFiles []string) []string {
 // Diff calculates the list of paths that need to be built based on the list of
 func Diff(manifestPaths []string, baseBranch string, mainBranch bool) ([]string, error) {
 	// Find components and dependency manifests
-	components, dependencies, err := readManifests(manifestPaths)
-	if err != nil {
-		return []string{}, fmt.Errorf("cannot load dependencies: %s", err)
+	components, dependencies, errs := manifests.Read(manifestPaths, true)
+	if errs != nil {
+		errstrings := make([]string, len(errs))
+		for i, e := range errs {
+			errstrings[i] = string(e.Error())
+		}
+
+		return []string{}, fmt.Errorf("cannot load dependencies:\n%s", strings.Join(errstrings, "\n"))
 	}
 
 	// Get changed files

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -1,4 +1,4 @@
-package diff
+package manifests
 
 import (
 	"fmt"
@@ -16,7 +16,7 @@ func chdir(dir string) {
 	}
 }
 
-func Test_readManifests(t *testing.T) {
+func Test_Read(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		panic(fmt.Errorf("Error finding current directory: %s", err))
@@ -76,17 +76,17 @@ func Test_readManifests(t *testing.T) {
 				panic(fmt.Errorf("Error finding dependency manifests: %s", err))
 			}
 
-			got, got1, err := readManifests(manifests)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("readManifests() error = %v, wantErr %v", err, tt.wantErr)
+			got, got1, errs := Read(manifests, true)
+			if (errs != nil) != tt.wantErr {
+				t.Errorf("Read() error = %v, wantErr %v", errs, tt.wantErr)
 				return
 			}
 
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("readManifests() got = %#v, want %#v", got, tt.want)
+				t.Errorf("Read() got = %#v, want %#v", got, tt.want)
 			}
 			if !reflect.DeepEqual(got1, tt.want1) {
-				t.Errorf("readManifests() got1 = %#v, want %#v", got1, tt.want1)
+				t.Errorf("Read() got1 = %#v, want %#v", got1, tt.want1)
 			}
 		})
 	}


### PR DESCRIPTION
Adds a command to print the dependency graph. Output on the fixture repo looks like the following:

```
Found 8 component(s). Dependency structure:

app2 -> libs/lib2, libs/lib3
app3 -> libs/lib3
app4 ->
libs/lib1 -> libs/lib3
libs/lib2 -> libs/lib3
libs/lib3 ->
stack1 -> app1, app2, app3
app1 -> libs/lib1, libs/lib2
```

It can also do graphical output using GraphViz, the result of which looks like this:

![test](https://user-images.githubusercontent.com/1517854/39636538-70892d78-4fb8-11e8-8377-106129b83f56.png)


