### PR TITLE
Add the option to rebuild strong dependencies of affected components

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,22 @@ $ monobuild diff --dependencies
 Both modes also support DOT output with `--dot`. You can also print
 the entire graph with the affected components with `--dot-highlight`.
 
+#### Rebuilding strong dependencies
+
+The assumption behind strong dependencies is that their outcome is required
+for the dependent builds to proceed. In most cases, this means that if no
+changes affected a component, the build does not need to run, because the outcome
+(e.g. a build artifact) already exists from a previous run of the build (when
+that component was affected).
+
+In certain situations, it could be useful to run the build again, to ensure its
+output is present. This will result in wasted work, but ensures builds won't
+fail because, for example, an artifact cache was lost. The wasted work can
+also largely be prevented by making builds idempotent.
+
+Monobuild supports this with an `--rebuild-strong` option on `diff`, which will
+include strong dependencies of all components affected by the change.
+
 ### Override the manifest matching
 
 If you want to use a different filename for the manifest files, you can do so

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -56,7 +56,7 @@ func Print(dependencyFilesGlob string, dotFormat bool, printDependencies bool) (
 }
 
 // Diff is 'monobuild diff'
-func Diff(dependencyFilesGlob string, mainBranch bool, baseBranch string, dotFormat bool, printDependencies bool) (graph.Graph, graph.Graph, []string, error) {
+func Diff(dependencyFilesGlob string, mainBranch bool, baseBranch string, includeStrong bool, dotFormat bool, printDependencies bool) (graph.Graph, graph.Graph, []string, error) {
 	manifestFiles, err := doublestar.Glob(dependencyFilesGlob)
 	if err != nil {
 		return graph.Graph{}, graph.Graph{}, []string{}, fmt.Errorf("error finding dependency manifests: %s", err)
@@ -82,6 +82,11 @@ func Diff(dependencyFilesGlob string, mainBranch bool, baseBranch string, dotFor
 	impacted := diff.Impacted(changedComponents, dependencies)
 
 	buildSchedule := dependencies.FilterEdges([]int{graph.Strong})
+
+	if includeStrong {
+		strong := buildSchedule.Descendants(impacted)
+		impacted = append(impacted, strong...)
+	}
 
 	return dependencies, buildSchedule, impacted, nil
 }

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -10,6 +10,7 @@ import (
 
 var baseBranch string
 var mainBranch bool
+var rebuildStrong bool
 var dotHighlight bool
 
 var diffCmd = &cobra.Command{
@@ -31,12 +32,13 @@ func init() {
 
 	diffCmd.Flags().StringVar(&baseBranch, "base-branch", "master", "Base branch to use for comparison")
 	diffCmd.Flags().BoolVar(&mainBranch, "main-branch", false, "Run in main branch mode (i.e. only compare with parent commit)")
+	diffCmd.Flags().BoolVar(&rebuildStrong, "rebuild-strong", false, "Include all strong dependencies of affected components")
 	diffCmd.Flags().BoolVar(&printDependencies, "dependencies", false, "Ouput the dependencies, not the build schedule")
 	diffCmd.Flags().BoolVar(&dotFormat, "dot", false, "Print in DOT format for GraphViz")
 }
 
 func diffFn(cmd *cobra.Command, args []string) {
-	dependencies, schedule, impacted, err := cli.Diff(dependencyFilesGlob, mainBranch, baseBranch, dotFormat, printDependencies)
+	dependencies, schedule, impacted, err := cli.Diff(dependencyFilesGlob, mainBranch, baseBranch, rebuildStrong, dotFormat, printDependencies)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
See the readme changes for details. 

This is an option that makes it easier to implement certain build strategies where strong dependencies can't be relied upon and _may_ not need rebuilding. Instead, they can be rebuilt every time and the optimisation to avoid extra work can be done within the build itself.

