### PR TITLE
Add support for scoping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test: install
 
 build: install $(GOPATH)/bin/monobuild
 
-~/go/bin/monobuild: ./monobuild.go cmd/*.go diff/*.go graph/*.go manifests/*.go set/*.go 
+~/go/bin/monobuild: ./monobuild.go cmd/*.go diff/*.go graph/*.go manifests/*.go set/*.go cli/*.go
 	@go install github.com/charypar/monobuild
 
 # Dependencies

--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ include strong dependencies of all components affected by the change.
 If you want to use a different filename for the manifest files, you can do so
 using the global `--manifests` flag.
 
+### Scoping
+
+You can scope the results of both `diff` and `print` to a given component
+and its dependencies using the `--scope` flag
+
 ### Creating a Makefile
 
 Monobuild can also generate a `Makefile`, that can be used by individual

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func diffFn(cmd *cobra.Command, args []string) {
-	dependencies, schedule, impacted, err := cli.Diff(dependencyFilesGlob, mainBranch, baseBranch, rebuildStrong, dotFormat, printDependencies)
+	dependencies, schedule, impacted, err := cli.Diff(dependencyFilesGlob, mainBranch, baseBranch, rebuildStrong, scope)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func printFn(cmd *cobra.Command, args []string) {
-	dependencies, schedule, impacted, err := cli.Print(dependencyFilesGlob, dotFormat, printDependencies)
+	dependencies, schedule, impacted, err := cli.Print(dependencyFilesGlob, scope)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,9 +16,11 @@ history.`,
 }
 
 var dependencyFilesGlob string
+var scope string
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&dependencyFilesGlob, "dependency-files", "**/Dependencies", "Search pattern for dependency files")
+	rootCmd.PersistentFlags().StringVar(&scope, "scope", "", "Scope output to a single component and its dependencies")
 }
 
 // Execute the CLI

--- a/set/set.go
+++ b/set/set.go
@@ -60,6 +60,20 @@ func (s Set) Union(other Set) Set {
 	return result
 }
 
+// Intersect returns a set with all members of the original set which are
+// also in the other set
+func (s Set) Intersect(other Set) Set {
+	result := New([]string{})
+
+	for m := range s.members {
+		if other.Has(m) {
+			result.Add(m)
+		}
+	}
+
+	return result
+}
+
 // AsStrings returns the Set as a string slice
 func (s Set) AsStrings() []string {
 	Set := make([]string, 0, len(s.members))


### PR DESCRIPTION
Resolves #8.

Add a global `--scope` flag, which limits monobuild output to a single component "subtree" (the component and all its dependencies).