### PR TITLE
Top level components filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,10 +213,18 @@ include strong dependencies of all components affected by the change.
 If you want to use a different filename for the manifest files, you can do so
 using the global `--manifests` flag.
 
-### Scoping
+### Filters
+
+#### Scope
 
 You can scope the results of both `diff` and `print` to a given component
 and its dependencies using the `--scope` flag
+
+#### Top-level components
+
+Sometimes it's useful to know the "entrypoints" into your dependency graph -
+the components that nothing depends on (typically services or applications).
+You can list only those with a `--top-level` flag on both `diff` and `print`.
 
 ### Creating a Makefile
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -38,7 +38,7 @@ func init() {
 }
 
 func diffFn(cmd *cobra.Command, args []string) {
-	dependencies, schedule, impacted, err := cli.Diff(dependencyFilesGlob, mainBranch, baseBranch, rebuildStrong, scope)
+	dependencies, schedule, impacted, err := cli.Diff(dependencyFilesGlob, mainBranch, baseBranch, rebuildStrong, scope, topLevel)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/print.go
+++ b/cmd/print.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func printFn(cmd *cobra.Command, args []string) {
-	dependencies, schedule, impacted, err := cli.Print(dependencyFilesGlob, scope)
+	dependencies, schedule, impacted, err := cli.Print(dependencyFilesGlob, scope, topLevel)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,10 +17,12 @@ history.`,
 
 var dependencyFilesGlob string
 var scope string
+var topLevel bool
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&dependencyFilesGlob, "dependency-files", "**/Dependencies", "Search pattern for dependency files")
 	rootCmd.PersistentFlags().StringVar(&scope, "scope", "", "Scope output to a single component and its dependencies")
+	rootCmd.PersistentFlags().BoolVar(&topLevel, "top-level", false, "Only list top-level components that nothing depends on")
 }
 
 // Execute the CLI


### PR DESCRIPTION
Resolves #9.

This adds a `--top-level` flag which only displays the components that are not being depended upon. This is often useful to identify deployment targets.

The flag works on both `diff` and `print` and can be combined with other flags, including `--rebuild-strong` on `diff`.