### PR TITLE
Clean up CLI code

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -31,7 +31,6 @@ func loadManifests(globPattern string) ([]string, graph.Graph, graph.Graph, erro
 		return []string{}, graph.Graph{}, graph.Graph{}, fmt.Errorf("%s", joinErrors("cannot load dependencies:", errs))
 	}
 
-	// Find impacted components
 	dependencies := deps.AsGraph()
 	buildSchedule := dependencies.FilterEdges([]int{graph.Strong})
 
@@ -127,6 +126,7 @@ func Diff(dependencyFilesGlob string, mode diff.Mode, scope Scope, includeStrong
 		return graph.Graph{}, graph.Graph{}, []string{}, fmt.Errorf("cannot find changes: %s", err)
 	}
 
+	// Find impacted components
 	changedComponents := manifests.FilterComponents(components, changes)
 	impacted := diff.Impacted(changedComponents, dependencies)
 

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -25,7 +25,7 @@ func loadManifests(globPattern string) ([]string, graph.Graph, graph.Graph, erro
 		return []string{}, graph.Graph{}, graph.Graph{}, fmt.Errorf("error finding dependency manifests: %s", err)
 	}
 
-	// Find components and dependency manifests
+	// Find components and dependencies
 	components, deps, errs := manifests.Read(manifestFiles, false)
 	if errs != nil {
 		return []string{}, graph.Graph{}, graph.Graph{}, fmt.Errorf("%s", joinErrors("cannot load dependencies:", errs))

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -73,7 +73,7 @@ type OutputOptions struct {
 }
 
 // Format output for the command line, filtering nodes only to those in the 'filter' slice.
-// Output options can be set using 'opts
+// Output options can be set using 'opts'
 func Format(dependencies graph.Graph, schedule graph.Graph, filter []string, opts OutputOptions) string {
 	if opts.Format == Dot && opts.Type == Dependencies {
 		return dependencies.Dot(filter)

--- a/cli/filter.go
+++ b/cli/filter.go
@@ -1,0 +1,60 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/charypar/monobuild/graph"
+	"github.com/charypar/monobuild/set"
+)
+
+type filter struct {
+	components set.Set
+	filtered   set.Set
+}
+
+func newFilter(components []string, filtered []string) filter {
+	componentsSet := set.New(components)
+	var filteredSet set.Set
+	if len(filtered) < 1 {
+		filteredSet = componentsSet
+	} else {
+		filteredSet = set.New(filtered)
+	}
+
+	return filter{components: componentsSet, filtered: filteredSet}
+}
+
+func (f *filter) scopeTo(component string, dependencies graph.Graph) error {
+	if !f.components.Has(component) {
+		return fmt.Errorf("cannot scope to '%s', not a component", component)
+	}
+
+	scoped := set.New(append(dependencies.Descendants([]string{component}), component))
+	f.filtered = f.filtered.Intersect(scoped)
+
+	return nil
+}
+
+func (f *filter) onlyTop(dependencies graph.Graph) {
+	reverse := dependencies.Reverse()
+	vertices := dependencies.Vertices()
+
+	topLevel := make([]string, 0, len(vertices))
+	for i := range vertices {
+		if len(reverse.Children(vertices[i:i+1])) < 1 {
+			topLevel = append(topLevel, vertices[i])
+		}
+	}
+
+	f.filtered = f.filtered.Intersect(set.New(topLevel))
+}
+
+func (f *filter) addStrong(buildSchedule graph.Graph) {
+	strong := buildSchedule.Descendants(f.filtered.AsStrings())
+
+	f.filtered = f.filtered.Union(set.New(strong))
+}
+
+func (f *filter) AsStrings() []string {
+	return f.filtered.AsStrings()
+}

--- a/cli/filter.go
+++ b/cli/filter.go
@@ -36,6 +36,7 @@ func (f *filter) scopeTo(component string, dependencies graph.Graph) error {
 }
 
 func (f *filter) onlyTop(dependencies graph.Graph) {
+	// FIXME this algorithm probably belongs to graph
 	reverse := dependencies.Reverse()
 	vertices := dependencies.Vertices()
 

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -5,14 +5,19 @@ import (
 	"log"
 
 	"github.com/charypar/monobuild/cli"
+	"github.com/charypar/monobuild/diff"
 	"github.com/spf13/cobra"
 )
 
-var baseBranch string
-var baseCommit string
-var mainBranch bool
-var rebuildStrong bool
-var dotHighlight bool
+type diffOptions struct {
+	baseBranch    string
+	baseCommit    string
+	mainBranch    bool
+	rebuildStrong bool
+	dotHighlight  bool
+}
+
+var diffOpts diffOptions
 
 var diffCmd = &cobra.Command{
 	Use:   "diff",
@@ -31,19 +36,49 @@ the original dependeny graph (using all dependencies).`,
 func init() {
 	rootCmd.AddCommand(diffCmd)
 
-	diffCmd.Flags().StringVar(&baseBranch, "base-branch", "master", "Base branch to use for comparison")
-	diffCmd.Flags().StringVar(&baseCommit, "base-commit", "HEAD^1", "Base commit to compare with (useful in main-brahnch mode when using rebase merging)")
-	diffCmd.Flags().BoolVar(&mainBranch, "main-branch", false, "Run in main branch mode (i.e. only compare with parent commit)")
-	diffCmd.Flags().BoolVar(&rebuildStrong, "rebuild-strong", false, "Include all strong dependencies of affected components")
-	diffCmd.Flags().BoolVar(&printDependencies, "dependencies", false, "Ouput the dependencies, not the build schedule")
-	diffCmd.Flags().BoolVar(&dotFormat, "dot", false, "Print in DOT format for GraphViz")
+	diffCmd.Flags().StringVar(&diffOpts.baseBranch, "base-branch", "master", "Base branch to use for comparison")
+	diffCmd.Flags().StringVar(&diffOpts.baseCommit, "base-commit", "HEAD^1", "Base commit to compare with (useful in main-brahnch mode when using rebase merging)")
+	diffCmd.Flags().BoolVar(&diffOpts.mainBranch, "main-branch", false, "Run in main branch mode (i.e. only compare with parent commit)")
+	diffCmd.Flags().BoolVar(&diffOpts.rebuildStrong, "rebuild-strong", false, "Include all strong dependencies of affected components")
+	diffCmd.Flags().BoolVar(&commonOpts.printDependencies, "dependencies", false, "Ouput the dependencies, not the build schedule")
+	diffCmd.Flags().BoolVar(&commonOpts.dotFormat, "dot", false, "Print in DOT format for GraphViz")
 }
 
 func diffFn(cmd *cobra.Command, args []string) {
-	dependencies, schedule, impacted, err := cli.Diff(dependencyFilesGlob, mainBranch, baseBranch, baseCommit, rebuildStrong, scope, topLevel)
+	// first we tediously process the CLI flags
+
+	var branchMode diff.BranchMode
+	if diffOpts.mainBranch {
+		branchMode = diff.Main
+	} else {
+		branchMode = diff.Feature
+	}
+
+	var format cli.OutputFormat
+	if commonOpts.dotFormat {
+		format = cli.Dot
+	} else {
+		format = cli.Text
+	}
+
+	diffMode := diff.Mode{Mode: branchMode, BaseBranch: diffOpts.baseBranch, BaseCommit: diffOpts.baseCommit}
+	scope := cli.Scope{Scope: commonOpts.scope, TopLevel: commonOpts.topLevel}
+
+	var outType cli.OutputType
+	if commonOpts.printDependencies {
+		outType = cli.Dependencies
+	} else {
+		outType = cli.Schedule
+	}
+
+	outputOpts := cli.OutputOptions{Format: format, Type: outType}
+
+	// run the CLI command
+
+	dependencies, schedule, impacted, err := cli.Diff(commonOpts.dependencyFilesGlob, diffMode, scope, diffOpts.rebuildStrong)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	fmt.Print(cli.Format(dependencies, schedule, impacted, dotFormat, printDependencies))
+	fmt.Print(cli.Format(dependencies, schedule, impacted, outputOpts))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,14 +15,20 @@ components live side by side) and decide what should be built, given the git
 history.`,
 }
 
-var dependencyFilesGlob string
-var scope string
-var topLevel bool
+type commonOptions struct {
+	dependencyFilesGlob string
+	scope               string
+	topLevel            bool
+	printDependencies   bool
+	dotFormat           bool
+}
+
+var commonOpts commonOptions
 
 func init() {
-	rootCmd.PersistentFlags().StringVar(&dependencyFilesGlob, "dependency-files", "**/Dependencies", "Search pattern for dependency files")
-	rootCmd.PersistentFlags().StringVar(&scope, "scope", "", "Scope output to a single component and its dependencies")
-	rootCmd.PersistentFlags().BoolVar(&topLevel, "top-level", false, "Only list top-level components that nothing depends on")
+	rootCmd.PersistentFlags().StringVar(&commonOpts.dependencyFilesGlob, "dependency-files", "**/Dependencies", "Search pattern for dependency files")
+	rootCmd.PersistentFlags().StringVar(&commonOpts.scope, "scope", "", "Scope output to a single component and its dependencies")
+	rootCmd.PersistentFlags().BoolVar(&commonOpts.topLevel, "top-level", false, "Only list top-level components that nothing depends on")
 }
 
 // Execute the CLI


### PR DESCRIPTION
Refactor some of the CLI code handling, this

- introduces hopefully a little more stable API for library use
- reduces repeated manifest loading and output filtering code in the CLI module
- possibly marginally speeds up the output filtering for _large_ repos (by reducing translations between 
`set` and `[]string`)