### PR TITLE
Handle dependencies with common prefixes.

### DIFF
--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -141,7 +141,7 @@ func FilterComponents(components []string, changedFiles []string) []string {
 
 	for _, component := range components {
 		for _, change := range changedFiles {
-			if strings.HasPrefix(change, component) {
+			if strings.HasPrefix(change, component + "/") {
 				changedComponents = append(changedComponents, component)
 				break
 			}


### PR DESCRIPTION
We're adding a new project to a monorepo that uses monobuild.  This
project is a rewrite of an old service that we need to keep running
in parallel for a while.  The old service is named `api` and the new
service is named `api-v2`.

Monobuild currently checks if a component has changes by checking if any
of the files that have changed share a prefix with the folder of each of
the components.  This is done without a trailing slash, so a change in
`lib/api-v2/Dockerfile` is matched as changing the `lib/api` service.

This commit fixes the issue by comparing files changed against the
component directory _with_ a trailing slash rather than without.

Might have been an option to not trim the trailing slashes in the first
place but that's a much more sweeping change that breaks consumers a
bit, and not something I'd want to be responsible for.