### PR TITLE
Fix output of diff when there are no changes to any components

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -97,7 +97,7 @@ func Print(dependencyFilesGlob string, scope Scope) (graph.Graph, graph.Graph, [
 		return graph.Graph{}, graph.Graph{}, []string{}, err
 	}
 
-	selection := newFilter(components, []string{})
+	selection := newFilter(components, components)
 
 	if scope.Scope != "" {
 		err = selection.scopeTo(scope.Scope, dependencies)

--- a/cli/filter.go
+++ b/cli/filter.go
@@ -14,12 +14,7 @@ type filter struct {
 
 func newFilter(components []string, filtered []string) filter {
 	componentsSet := set.New(components)
-	var filteredSet set.Set
-	if len(filtered) < 1 {
-		filteredSet = componentsSet
-	} else {
-		filteredSet = set.New(filtered)
-	}
+	filteredSet := set.New(filtered)
 
 	return filter{components: componentsSet, filtered: filteredSet}
 }

--- a/manifests/manifests.go
+++ b/manifests/manifests.go
@@ -141,7 +141,7 @@ func FilterComponents(components []string, changedFiles []string) []string {
 
 	for _, component := range components {
 		for _, change := range changedFiles {
-			if strings.HasPrefix(change, component + "/") {
+			if strings.HasPrefix(change, component+"/") {
 				changedComponents = append(changedComponents, component)
 				break
 			}

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/bmatcuk/doublestar"
@@ -81,6 +82,8 @@ func Test_Read(t *testing.T) {
 				t.Errorf("Read() error = %v, wantErr %v", errs, tt.wantErr)
 				return
 			}
+
+			sort.Strings(got)
 
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Read() got = %#v, want %#v", got, tt.want)

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -163,6 +163,14 @@ func Test_FilterComponents(t *testing.T) {
 			[]string{"component/one"},
 		},
 		{
+			"only matches full component name",
+			args{
+				[]string{"a/component", "a/component-v2"},
+				[]string{"a/component-v2/file.txt"},
+			},
+			[]string{"a/component-v2"},
+		},
+		{
 			"handles a complex case correctly",
 			args{
 				[]string{

--- a/manifests/manifests_test.go
+++ b/manifests/manifests_test.go
@@ -171,6 +171,14 @@ func Test_FilterComponents(t *testing.T) {
 			[]string{"a/component-v2"},
 		},
 		{
+			"changes outside of components result in no changes",
+			args{
+				[]string{"component/one", "component/two", "something-else"},
+				[]string{".github/CODEOWNERS"},
+			},
+			[]string{},
+		},
+		{
 			"handles a complex case correctly",
 			args{
 				[]string{


### PR DESCRIPTION
This fixes an issue (#19) where running `monobuild diff` with no changes or only changes that don't affect any known components reverted the behaviour to `monobuild print`. 

The root cause of this was a poor attempt at DRY in the filtering code which supports `--scope`, `--rebuild-strong` and `--top-level` flags and is common to `diff` and `print`. Instead of recognising `print` by an empty list of changes, print now behaves the same as a diff, where every single component was affected (this could be a neat way of implementing print on top of diff).

/cc @jennysharps